### PR TITLE
Fix pickup duplication on tracker

### DIFF
--- a/map/src/PlandoBuilder.js
+++ b/map/src/PlandoBuilder.js
@@ -25,7 +25,6 @@ const relevantCodes = ["HC", "AC", "EC", "KS", "MS", "TP", "RB", "EV", "SK"];
 const DUNGEON_KEYS = ["EV|0", "EV|2", "EV|4"]
 const DEFAULT_DATA = {
     '-280256': {label: "Energy Cell", value: "EC|1"},
-    '-1680104': {label: "100 Experience", value: "EX|100"},
     '-12320248': {label: "Nothing", value: "NO|1"}
 }
 
@@ -56,7 +55,7 @@ const modes_by_key = {"Shared": "Shared", "None": "Solo", "Split": "Shards Race"
 const COOP_MODES = Object.keys(modes_by_key).map((k) => { return {label: modes_by_key[k], value: k} });
 const SHARE_TYPES = ["WorldEvents", "Misc", "Upgrades", "Teleporters", "Skills"]
 const crs = getMapCrs();
-const DANGEROUS = [-280256, -1680104, -12320248]
+const DANGEROUS = [-280256, -12320248]
 const paths = Object.keys(presets);
 
 const dev = window.document.URL.includes("devshell")

--- a/util.py
+++ b/util.py
@@ -44,7 +44,6 @@ extra_PBT = [
     PickLoc(52, 'Mapstone 8', 'Mapstone', 'MS8', 0, 52),
     PickLoc(56, 'Mapstone 9', 'Mapstone', 'MS9', 0, 56),
     PickLoc(-280256, "EC", "Glades", "SunkenGladesFirstEC", -28, -256),
-    PickLoc(-1680104, "EX100", "Grove", "UnsafeSpiritTree100Ex", -168, -104),
     PickLoc(-2399488, "EVWarmth", "Horu", "FinalEscape", -240, 512),
     PickLoc(-12320248, "Plant", "Forlorn", "ForlornEscapePlant", -1232, -248),
     PickLoc(2, "SPAWN", "Glades", "FirstPickup", 189, -210),


### PR DESCRIPTION
Duplication of the SpiritTreeExp was caused by having the pickup returned twice by `/picksbytype`. Once from `areas.ori` and once from `extra_PBT`. Removing it from `extra_PBT` fixes the issue.

I also removed it from the plando builder list of dangerous pickups as it no longer is.