### PR TITLE
Add custom logic pathset info into the seed.

### DIFF
--- a/cli_gen.py
+++ b/cli_gen.py
@@ -522,7 +522,31 @@ class CLISeedParams(object):
         for name, lps in presets.items():
             if lps == pathset:
                 return name
-        return "Custom"
+        pathMaskDict = {
+            LogicPath.CASUAL_CORE: 1 << 0,
+            LogicPath.CASUAL_DBOOST: 1 << 1,
+            LogicPath.STANDARD_CORE: 1 << 2,
+            LogicPath.STANDARD_DBOOST: 1 << 3,
+            LogicPath.STANDARD_LURE: 1 << 4,
+            LogicPath.STANDARD_ABILITIES: 1 << 5,
+            LogicPath.EXPERT_CORE: 1 << 6,
+            LogicPath.EXPERT_DBOOST: 1 << 7,          
+            LogicPath.EXPERT_LURE: 1 << 8,
+            LogicPath.EXPERT_ABILITIES: 1 << 9,
+            LogicPath.DBASH: 1 << 10,
+            LogicPath.MASTER_CORE: 1 << 11,
+            LogicPath.MASTER_DBOOST: 1 << 12,
+            LogicPath.MASTER_LURE: 1 << 13,
+            LogicPath.MASTER_ABILITIES: 1 << 14,
+            LogicPath.GJUMP: 1 << 15,
+            LogicPath.GLITCHED: 1 << 16,
+            LogicPath.TIMED_LEVEL: 1 << 17,
+            LogicPath.INSANE: 1 << 18,
+        }
+        pathMask = 0
+        for path in self.logic_paths:
+            pathMask |= pathMaskDict[path]
+        return "Custom" + str(pathMask)
 
     def flag_line(self, verbose_paths=False):
         flags = []

--- a/cli_gen.py
+++ b/cli_gen.py
@@ -5,7 +5,7 @@ import re
 import pickle
 from collections import OrderedDict, defaultdict, Counter
 
-from util import enums_from_strlist
+from util import enums_from_strlist, get_preset_from_paths
 from enums import MultiplayerGameType, ShareType, Variation, LogicPath, KeyMode, PathDifficulty, presets
 from seedbuilder.generator import SeedGenerator
 
@@ -517,43 +517,12 @@ class CLISeedParams(object):
 
                 output.write(line + "\n")
 
-    def get_preset(self):
-        pathset = set(self.logic_paths)
-        for name, lps in presets.items():
-            if lps == pathset:
-                return name
-        pathMaskDict = {
-            LogicPath.CASUAL_CORE: 1 << 0,
-            LogicPath.CASUAL_DBOOST: 1 << 1,
-            LogicPath.STANDARD_CORE: 1 << 2,
-            LogicPath.STANDARD_DBOOST: 1 << 3,
-            LogicPath.STANDARD_LURE: 1 << 4,
-            LogicPath.STANDARD_ABILITIES: 1 << 5,
-            LogicPath.EXPERT_CORE: 1 << 6,
-            LogicPath.EXPERT_DBOOST: 1 << 7,          
-            LogicPath.EXPERT_LURE: 1 << 8,
-            LogicPath.EXPERT_ABILITIES: 1 << 9,
-            LogicPath.DBASH: 1 << 10,
-            LogicPath.MASTER_CORE: 1 << 11,
-            LogicPath.MASTER_DBOOST: 1 << 12,
-            LogicPath.MASTER_LURE: 1 << 13,
-            LogicPath.MASTER_ABILITIES: 1 << 14,
-            LogicPath.GJUMP: 1 << 15,
-            LogicPath.GLITCHED: 1 << 16,
-            LogicPath.TIMED_LEVEL: 1 << 17,
-            LogicPath.INSANE: 1 << 18,
-        }
-        pathMask = 0
-        for path in self.logic_paths:
-            pathMask |= pathMaskDict[path]
-        return "Custom" + str(pathMask)
-
     def flag_line(self, verbose_paths=False):
         flags = []
         if verbose_paths:
             flags.append("lps=%s" % "+".join([lp.capitalize() for lp in self.logic_paths]))
         else:
-            flags.append(self.get_preset())
+            flags.append(get_preset_from_paths(presets, self.logic_paths))
         flags.append(self.key_mode)
         if Variation.WARMTH_FRAGMENTS in self.variations:
             flags.append("Frags/%s/%s" % (self.frag_count - self.frag_extra, self.frag_count))

--- a/seedbuilder/seedparams.py
+++ b/seedbuilder/seedparams.py
@@ -3,7 +3,7 @@ from google.appengine.ext import ndb
 import logging as log
 import random
 
-from util import enums_from_strlist, picks_by_coord
+from util import enums_from_strlist, picks_by_coord, get_preset_from_paths
 from enums import (MultiplayerGameType, ShareType, Variation, LogicPath, KeyMode, PathDifficulty, presets)
 from collections import OrderedDict
 from seedbuilder.generator import SeedGenerator
@@ -281,7 +281,7 @@ class SeedGenParams(ndb.Model):
             "fillAlg": "Balanced" if self.balanced else "Classic",
             "expPool": self.exp_pool,
             "keyMode": self.key_mode.value,
-            "pathMode": self.get_preset(),
+            "pathMode": get_preset_from_paths(presets, self.logic_paths),
             "pathDiff": self.path_diff.value,
             "cellFreq": self.cell_freq,
             "fragCount": self.frag_count,
@@ -398,37 +398,6 @@ class SeedGenParams(ndb.Model):
             outlines += ["\t%-35s %s" % (l.area, n) for (l, n, _) in sorted(group, key=lambda grpline: grpline[2])]
         return "\n".join(outlines[1:])
 
-    def get_preset(self):
-        pathset = set(self.logic_paths)
-        for name, lps in presets.items():
-            if lps == pathset:
-                return name
-        pathMaskDict = {
-            LogicPath.CASUAL_CORE: 1 << 0,
-            LogicPath.CASUAL_DBOOST: 1 << 1,
-            LogicPath.STANDARD_CORE: 1 << 2,
-            LogicPath.STANDARD_DBOOST: 1 << 3,
-            LogicPath.STANDARD_LURE: 1 << 4,
-            LogicPath.STANDARD_ABILITIES: 1 << 5,
-            LogicPath.EXPERT_CORE: 1 << 6,
-            LogicPath.EXPERT_DBOOST: 1 << 7,          
-            LogicPath.EXPERT_LURE: 1 << 8,
-            LogicPath.EXPERT_ABILITIES: 1 << 9,
-            LogicPath.DBASH: 1 << 10,
-            LogicPath.MASTER_CORE: 1 << 11,
-            LogicPath.MASTER_DBOOST: 1 << 12,
-            LogicPath.MASTER_LURE: 1 << 13,
-            LogicPath.MASTER_ABILITIES: 1 << 14,
-            LogicPath.GJUMP: 1 << 15,
-            LogicPath.GLITCHED: 1 << 16,
-            LogicPath.TIMED_LEVEL: 1 << 17,
-            LogicPath.INSANE: 1 << 18,
-        }
-        pathMask = 0
-        for path in self.logic_paths:
-            pathMask |= pathMaskDict[path]
-        return "Custom" + str(pathMask)
-
     def flag_line(self, verbose_paths=False):
         flags = []
         if self.is_plando:
@@ -437,7 +406,7 @@ class SeedGenParams(ndb.Model):
             if verbose_paths:
                 flags.append("lps=%s" % "+".join([lp.capitalize() for lp in self.logic_paths]))
             else:
-                flags.append(self.get_preset())
+                flags.append(get_preset_from_paths(presets, self.logic_paths))
             flags.append(self.key_mode)
             if Variation.WARMTH_FRAGMENTS in self.variations:
                 flags.append("Frags/%s/%s" % (self.frag_req, self.frag_count))

--- a/seedbuilder/seedparams.py
+++ b/seedbuilder/seedparams.py
@@ -403,7 +403,31 @@ class SeedGenParams(ndb.Model):
         for name, lps in presets.items():
             if lps == pathset:
                 return name
-        return "Custom"
+        pathMaskDict = {
+            LogicPath.CASUAL_CORE: 1 << 0,
+            LogicPath.CASUAL_DBOOST: 1 << 1,
+            LogicPath.STANDARD_CORE: 1 << 2,
+            LogicPath.STANDARD_DBOOST: 1 << 3,
+            LogicPath.STANDARD_LURE: 1 << 4,
+            LogicPath.STANDARD_ABILITIES: 1 << 5,
+            LogicPath.EXPERT_CORE: 1 << 6,
+            LogicPath.EXPERT_DBOOST: 1 << 7,          
+            LogicPath.EXPERT_LURE: 1 << 8,
+            LogicPath.EXPERT_ABILITIES: 1 << 9,
+            LogicPath.DBASH: 1 << 10,
+            LogicPath.MASTER_CORE: 1 << 11,
+            LogicPath.MASTER_DBOOST: 1 << 12,
+            LogicPath.MASTER_LURE: 1 << 13,
+            LogicPath.MASTER_ABILITIES: 1 << 14,
+            LogicPath.GJUMP: 1 << 15,
+            LogicPath.GLITCHED: 1 << 16,
+            LogicPath.TIMED_LEVEL: 1 << 17,
+            LogicPath.INSANE: 1 << 18,
+        }
+        pathMask = 0
+        for path in self.logic_paths:
+            pathMask |= pathMaskDict[path]
+        return "Custom" + str(pathMask)
 
     def flag_line(self, verbose_paths=False):
         flags = []

--- a/util.py
+++ b/util.py
@@ -3,7 +3,7 @@ from flask import request, url_for
 from math import floor
 from collections import defaultdict, namedtuple
 from seedbuilder.oriparse import get_areas
-from enums import Variation
+from enums import Variation, LogicPath
 from datetime import datetime
 import itertools as _itertools
 import operator
@@ -735,3 +735,34 @@ layout_json = """
     ]
 }
 """
+
+def get_preset_from_paths(presets, logic_paths):
+    pathset = set(logic_paths)
+    for name, lps in presets.items():
+        if lps == pathset:
+            return name
+    path_masks = {
+        LogicPath.CASUAL_CORE: 1 << 0,
+        LogicPath.CASUAL_DBOOST: 1 << 1,
+        LogicPath.STANDARD_CORE: 1 << 2,
+        LogicPath.STANDARD_DBOOST: 1 << 3,
+        LogicPath.STANDARD_LURE: 1 << 4,
+        LogicPath.STANDARD_ABILITIES: 1 << 5,
+        LogicPath.EXPERT_CORE: 1 << 6,
+        LogicPath.EXPERT_DBOOST: 1 << 7,          
+        LogicPath.EXPERT_LURE: 1 << 8,
+        LogicPath.EXPERT_ABILITIES: 1 << 9,
+        LogicPath.DBASH: 1 << 10,
+        LogicPath.MASTER_CORE: 1 << 11,
+        LogicPath.MASTER_DBOOST: 1 << 12,
+        LogicPath.MASTER_LURE: 1 << 13,
+        LogicPath.MASTER_ABILITIES: 1 << 14,
+        LogicPath.GJUMP: 1 << 15,
+        LogicPath.GLITCHED: 1 << 16,
+        LogicPath.TIMED_LEVEL: 1 << 17,
+        LogicPath.INSANE: 1 << 18,
+    }
+    path_mask = 0
+    for path in logic_paths:
+        path_mask |= path_masks[path]
+    return "Custom" + str(path_mask)


### PR DESCRIPTION
Allows the dll to know the exact pathsets selected for in-game logic tracking.
Changes it so "Custom" seeds become "Custom1098" where the number encodes the pathsets that have been selected.
The dll already has this functionality.