### PR TITLE
Fix toggling dark mode

### DIFF
--- a/map/src/index.js
+++ b/map/src/index.js
@@ -9,7 +9,7 @@ const VALID_THEMES = ["cerulean", "cosmo", "cyborg", "darkly", "flatly", "journa
 (() => {
     if(localStorage.getItem("rememberMe") && !get_param('user'))
         return gotoUrl(`/login?redir=${encodeURIComponent(window.document.URL.split(".com")[1])}`)
-    let dark = get_flag("dark") || localStorage.getItem("dark")
+    let dark = get_param("dark") != null ? get_flag("dark") : localStorage.getItem("dark")
     let theme = get_param("theme") || localStorage.getItem("theme")
     if(theme && !localStorage.getItem("theme"))
         localStorage.setItem("theme", theme)


### PR DESCRIPTION
Previously it was impossible to switch to light mode while logged in.

This was because there are two sources for dark mode: local storage and template value (when logged in).
When changing the mode while logged in, the server sends the template val to the client, which copies it to local storage.
When then trying to change to light mode, the server sends the template val "false", which is ignored by the client because the local storage still has dark mode set.

This change makes the template val authoritative, and only falls back to local storage when it's not present.