### PR TITLE
Don't optimize away necessary quotes

### DIFF
--- a/map/.parcelrc
+++ b/map/.parcelrc
@@ -1,4 +1,6 @@
 {
   "extends": ["@parcel/config-default"],
-  "reporters":  ["...", "parcel-reporter-static-files-copy"]
+  "reporters":  ["...", "parcel-reporter-static-files-copy"],
+  "optimizers": { "*.html": [] }
+
 }

--- a/run_dev_server.sh
+++ b/run_dev_server.sh
@@ -27,4 +27,4 @@ if [ -z "${CLOUDSDK_PYTHON}" ]; then
     fi
 fi
 
-${CLOUDSDK_PYTHON} "$GCLOUD_CLI_ROOT/bin/dev_appserver.py" app.yaml --port "${APP_PORT:-"8080"}" --host "${APP_HOST:-"127.0.0.1"}" --enable_host_checking=false
+GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT} ${CLOUDSDK_PYTHON} "$GCLOUD_CLI_ROOT/bin/dev_appserver.py" app.yaml --port "${APP_PORT:-"8080"}" --host "${APP_HOST:-"127.0.0.1"}" --enable_host_checking=false


### PR DESCRIPTION
Parcel, upon building for production, would minify away quotation marks for data values on the `templateData` html element. This caused problems when those data values were replaced with empty strings, or hypothetically values with additional spaces. This disables all HTML optimization in parcel, which should not have a large effect as we only have one html file and it's of minimal size already. We may consider manually minifying this file if that optimization makes sense in the future.